### PR TITLE
UserInput() for bodymap + bm_color

### DIFF
--- a/appside/frames/body.js
+++ b/appside/frames/body.js
@@ -162,6 +162,7 @@ class BodyMapFrame extends Frame {
         this.title = frame_data.title;
         this.question = frame_data.question;
         this.statements = frame_data.statements;
+        this.user_input;
     }
 
     /**
@@ -200,6 +201,8 @@ class BodyMapFrame extends Frame {
         $(question).text(this.question);
         right.appendChild(question);
 
+        this.user_input = new Map();
+
         // checkboxes
         let i = 0;
         for (let stmt of this.statements) {
@@ -215,7 +218,23 @@ class BodyMapFrame extends Frame {
             $(label).text(stmt);
             right.appendChild(label);
             right.appendChild(document.createElement('br'));
+
+            this.user_input.set(name, 'false'); // all unchecked
         }
+
+        // next will be implemented in navigator?
+        let next = document.createElement('button');
+        $(next).attr('class', 'bodymap_button');
+        $(next).text('Next');
+        $(next).click(function() {
+            var choices = document.getElementsByTagName('input');
+            for (let each of choices) {
+                if (each.checked) {
+                    this.user_input.set(each.id, 'true');
+                }
+            }
+        }.bind(this));
+        right.appendChild(next);
 
         // append both columns to frame
         frame.appendChild(right);
@@ -223,6 +242,14 @@ class BodyMapFrame extends Frame {
 
         let old_frame = $('#frame')[0];
         old_frame.replaceWith(frame);
+    }
+
+    /**
+     * Returns data of user input
+     * including each statement's id and whether it was checked
+     */
+    userInput() {
+        return this.user_input;
     }
 }
 
@@ -371,11 +398,12 @@ class BodyMapColorFrame extends Frame {
             frame.right.appendChild(document.createElement('br'));
         }
 
+        // next will be implemented in navigator?
         let next = document.createElement('button');
         $(next).attr('class', 'bodymap_color_button');
         $(next).text('Next');
         $(next).click(function() {
-            var choices = document.getElementsByName(this.emotion + '_' + this.bodypart);
+            var choices = document.getElementsByTagName('input');;
             for (let each of choices) {
                 if (each.checked) { this.answer = each.id; } // only one checked
             }

--- a/appside/frames/body.js
+++ b/appside/frames/body.js
@@ -247,6 +247,8 @@ class BodyMapColorFrame extends Frame {
         this.qualifiers = frame_data.qualifiers;
         this.emotion;
         this.bodypart;
+        this.answer;
+        this.user_input;
     }
 
     /**
@@ -358,7 +360,7 @@ class BodyMapColorFrame extends Frame {
         for (let choice of this.qualifiers) {
             let radio = document.createElement('input');
             $(radio).attr('type', 'radio');
-            $(radio).attr('name', 'emotion');
+            $(radio).attr('name', this.emotion + '_' + this.bodypart);
             $(radio).attr('id', choice);
 
             let label = document.createElement('label');
@@ -368,6 +370,30 @@ class BodyMapColorFrame extends Frame {
             frame.right.appendChild(label);
             frame.right.appendChild(document.createElement('br'));
         }
+
+        let next = document.createElement('button');
+        $(next).attr('class', 'bodymap_color_button');
+        $(next).text('Next');
+        $(next).click(function() {
+            var choices = document.getElementsByName(this.emotion + '_' + this.bodypart);
+            for (let each of choices) {
+                if (each.checked) { this.answer = each.id; } // only one checked
+            }
+            this.user_input = new Map();
+            this.user_input.set('emotion', this.emotion);
+            this.user_input.set('bodypart', this.bodypart);
+            this.user_input.set('answer', this.answer);
+        }.bind(this));
+        frame.right.appendChild(next);
+
+    }
+
+    /**
+     * Returns data of user input
+     * including emotion, bodypart, and answer (qualifier)
+     */
+    userInput() {
+        return this.user_input;
     }
 }
 

--- a/appside/frames/body.js
+++ b/appside/frames/body.js
@@ -209,14 +209,17 @@ class BodyMapFrame extends Frame {
             let check = document.createElement('input');
             $(check).attr('type', 'checkbox');
             $(check).attr('id', name);
+            check.dataset.text = stmt;
             right.appendChild(check);
 
             let label = document.createElement('label');
+            $(label).attr('for', name);
             $(label).text(stmt);
+
             right.appendChild(label);
             right.appendChild(document.createElement('br'));
 
-            this.user_input.set(name, 'false'); // all unchecked
+            this.user_input.set(stmt, 'false'); // all unchecked
         }
 
         // next will be implemented in navigator?
@@ -235,7 +238,7 @@ class BodyMapFrame extends Frame {
 
     /**
      * Returns map of user input
-     * if render() is called, map with keys as each statement's id and value boolean;
+     * if render() is called, map with keys as each statement's text and value boolean;
      * otherwise, returns uninitialized map
      * @return map of user input
      */
@@ -243,7 +246,9 @@ class BodyMapFrame extends Frame {
         var choices = document.getElementsByTagName('input');
         for (let each of choices) {
             if (each.checked) {
-                this.user_input.set(each.id, 'true');
+                this.user_input.set(each.dataset.text, 'true');
+            } else {
+                this.user_input.set(each.dataset.text, 'false');
             }
         }
         return this.user_input;

--- a/appside/frames/body.js
+++ b/appside/frames/body.js
@@ -2,7 +2,7 @@
 
 /**
  * Rendering (View) code for body frames
- * @author Leah Perlmutter
+ * @author Leah Perlmutter, Rachel Sitt
  */
 
 
@@ -162,7 +162,7 @@ class BodyMapFrame extends Frame {
         this.title = frame_data.title;
         this.question = frame_data.question;
         this.statements = frame_data.statements;
-        this.user_input;
+        this.user_input = new Map();
     }
 
     /**
@@ -180,7 +180,6 @@ class BodyMapFrame extends Frame {
         // make a new empty div with id frame, not yet in the dom
         let frame = document.createElement('div');
         $(frame).attr('id', 'frame');
-
         let title = document.createElement('h2');
         $(title).text(this.title);
         frame.appendChild(title);
@@ -200,8 +199,6 @@ class BodyMapFrame extends Frame {
         let question = document.createElement('h4');
         $(question).text(this.question);
         right.appendChild(question);
-
-        this.user_input = new Map();
 
         // checkboxes
         let i = 0;
@@ -226,14 +223,6 @@ class BodyMapFrame extends Frame {
         let next = document.createElement('button');
         $(next).attr('class', 'bodymap_button');
         $(next).text('Next');
-        $(next).click(function() {
-            var choices = document.getElementsByTagName('input');
-            for (let each of choices) {
-                if (each.checked) {
-                    this.user_input.set(each.id, 'true');
-                }
-            }
-        }.bind(this));
         right.appendChild(next);
 
         // append both columns to frame
@@ -245,10 +234,18 @@ class BodyMapFrame extends Frame {
     }
 
     /**
-     * Returns data of user input
-     * including each statement's id and whether it was checked
+     * Returns map of user input
+     * if render() is called, map with keys as each statement's id and value boolean;
+     * otherwise, returns uninitialized map
+     * @return map of user input
      */
-    userInput() {
+    get_user_input() {
+        var choices = document.getElementsByTagName('input');
+        for (let each of choices) {
+            if (each.checked) {
+                this.user_input.set(each.id, 'true');
+            }
+        }
         return this.user_input;
     }
 }
@@ -275,7 +272,7 @@ class BodyMapColorFrame extends Frame {
         this.emotion;
         this.bodypart;
         this.answer;
-        this.user_input;
+        this.user_input = new Map();
     }
 
     /**
@@ -297,23 +294,24 @@ class BodyMapColorFrame extends Frame {
         $(title).text(this.title);
         frame.appendChild(title);
         
-        frame.left = document.createElement('div');
+        frame.left = document.createElement('div');             // displays body image and scale
         $(frame.left).attr('class', 'bodymap_color_frame_left');
 
-        frame.right = document.createElement('div');
+        frame.right = document.createElement('div');            // displays questionnaire and NEXT button
         $(frame.right).attr('class', 'bodymap_color_frame_right');
 
-        let greeting = document.createElement('h4');
+        let greeting = document.createElement('h4');            // displays when emotion/bodypart NOT specified
         $(greeting).text('Please select an emotion.');
         frame.left.appendChild(greeting);
 
-        let query = location.search.substring(14);
-        if (query.includes('/') && query.includes('_')) {
-            this.emotion = query.substring(1, query.indexOf('_'));
-            this.bodypart = query.substring(query.indexOf('_') + 1); // query after _
-            if (emotions.includes(this.emotion) && bodyparts.includes(this.bodypart)) {
-                this.render_left_col(frame);
-                this.render_right_col(frame);
+        // query format: ?bodymap_color&emotion=EMOTION&bodypart=BODYPART
+        var query = new URLSearchParams(location.search);
+        if (query.has('emotion') && query.has('bodypart')) {
+            if (emotions.includes(query.get('emotion')) && bodyparts.includes(query.get('bodypart'))) {
+                this.emotion = query.get('emotion');
+                this.bodypart = query.get('bodypart');
+                this.render_left_col(frame);                    // only renders when emotion is specified
+                this.render_right_col(frame);                   // only renders when bodypart is specified
             }
         }
 
@@ -402,25 +400,25 @@ class BodyMapColorFrame extends Frame {
         let next = document.createElement('button');
         $(next).attr('class', 'bodymap_color_button');
         $(next).text('Next');
-        $(next).click(function() {
-            var choices = document.getElementsByTagName('input');;
-            for (let each of choices) {
-                if (each.checked) { this.answer = each.id; } // only one checked
-            }
-            this.user_input = new Map();
-            this.user_input.set('emotion', this.emotion);
-            this.user_input.set('bodypart', this.bodypart);
-            this.user_input.set('answer', this.answer);
-        }.bind(this));
         frame.right.appendChild(next);
 
     }
 
     /**
-     * Returns data of user input
-     * including emotion, bodypart, and answer (qualifier)
+     * Returns map of user input
+     * if render() called before, with keys emotion, bodypart, and answer;
+     * values are undefined at default when not specified;
+     * if render() not called yet, returns empty map
+     * @return map of user input
      */
-    userInput() {
+    get_user_input() {
+        var choices = document.getElementsByTagName('input');;
+        for (let each of choices) {
+            if (each.checked) { this.answer = each.id; } // only one checked
+        }
+        this.user_input.set('emotion', this.emotion);
+        this.user_input.set('bodypart', this.bodypart);
+        this.user_input.set('answer', this.answer);
         return this.user_input;
     }
 }

--- a/appside/frames/body.js
+++ b/appside/frames/body.js
@@ -274,9 +274,9 @@ class BodyMapColorFrame extends Frame {
         this.title = frame_data.title;
         this.question = frame_data.question;
         this.qualifiers = frame_data.qualifiers;
-        this.emotion;
-        this.bodypart;
-        this.answer;
+        this.emotion = frame_data.emotion;
+        this.bodypart = frame_data.bodypart;
+        this.answer = null;
         this.user_input = new Map();
     }
 
@@ -289,8 +289,6 @@ class BodyMapColorFrame extends Frame {
      *
      **/
     render() {
-        let emotions = ['anger', 'disgust', 'envy', 'fear', 'guilt', 'happiness', 'love', 'sadness', 'shame'];
-        let bodyparts = ['head', 'neck', 'arms', 'chest', 'belly', 'legs'];
         // make a new empty div with id frame, not yet in the dom
         let frame = document.createElement('div');
         $(frame).attr('id', 'frame');
@@ -309,15 +307,9 @@ class BodyMapColorFrame extends Frame {
         $(greeting).text('Please select an emotion.');
         frame.left.appendChild(greeting);
 
-        // query format: ?bodymap_color&emotion=EMOTION&bodypart=BODYPART
-        var query = new URLSearchParams(location.search);
-        if (query.has('emotion') && query.has('bodypart')) {
-            if (emotions.includes(query.get('emotion')) && bodyparts.includes(query.get('bodypart'))) {
-                this.emotion = query.get('emotion');
-                this.bodypart = query.get('bodypart');
-                this.render_left_col(frame);                    // only renders when emotion is specified
-                this.render_right_col(frame);                   // only renders when bodypart is specified
-            }
+        if (this.emotion != null && this.bodypart != null) {
+            this.render_left_col(frame);                    // only renders when emotion is specified
+            this.render_right_col(frame);                   // only renders when bodypart is specified
         }
 
         frame.appendChild(frame.left);
@@ -346,7 +338,9 @@ class BodyMapColorFrame extends Frame {
         frame.left.innerHTML = '';
         const bodymap = document.createElement('img');
         $(bodymap).attr('class', 'bodymap_color_img');
-        $(bodymap).attr('src', 'images/' + this.emotion + '.png');
+        if (this.emotion != null) {
+            $(bodymap).attr('src', 'images/' + this.emotion + '.png');
+        }
 
         if (this.bodypart != null) {      // clipping picture when specified body part
             $(bodymap).attr('class', `bodymap_color_img bodymap_color_${this.bodypart}`);
@@ -392,6 +386,7 @@ class BodyMapColorFrame extends Frame {
             $(radio).attr('type', 'radio');
             $(radio).attr('name', this.emotion + '_' + this.bodypart);
             $(radio).attr('id', choice);
+            radio.dataset.text = choice;
 
             let label = document.createElement('label');
             $(label).attr('for', choice);
@@ -411,15 +406,17 @@ class BodyMapColorFrame extends Frame {
 
     /**
      * Returns map of user input
-     * if render() called before, with keys emotion, bodypart, and answer;
-     * values are undefined at default when not specified;
-     * if render() not called yet, returns empty map
+     * containing keys {
+     * 'emotion': null or string
+     * 'bodypart': null or string
+     * 'answer': null or string of qualifier
+     * }
      * @return map of user input
      */
     get_user_input() {
         var choices = document.getElementsByTagName('input');;
         for (let each of choices) {
-            if (each.checked) { this.answer = each.id; } // only one checked
+            if (each.checked) { this.answer = each.dataset.text; } // only one checked
         }
         this.user_input.set('emotion', this.emotion);
         this.user_input.set('bodypart', this.bodypart);

--- a/appside/test_frames.js
+++ b/appside/test_frames.js
@@ -15,7 +15,7 @@ $(document).ready(function() {
         'selection': selection_frame_main,
         'intro': intro_main,
         'bodymap_color_fwd': bodymap_color_fwd_main,
-        'bodymap_color': bodymap_color_main,
+        'bodymap_color': bodymap_color_main,    // requires 2 parameters [emotion, bodypart]
         'bodymap': bodymap_main,
     };
 

--- a/appside/test_frames.js
+++ b/appside/test_frames.js
@@ -27,19 +27,7 @@ $(document).ready(function() {
     let query_string = new URLSearchParams(location.search);
 
     if (query_string.has('frame')) {
-        let query = query_string.get('frame');
-
-        // checks if substring of query matches an element in page_types
-        // this allows flexibility and additional string in query (esp for bm_color)
-        var contains = function(element) {
-            if (query.includes(element)) {
-                query = element;
-                return true;
-            } // stops searching each element if true or no more elements to search
-        };
-        if (page_types.some(contains)) {
-            page_to_show = query;
-        }
+        page_to_show = query_string.get('frame');
     }
 
     let test_fcn = test_methods[page_to_show];

--- a/appside/test_frames.js
+++ b/appside/test_frames.js
@@ -23,12 +23,11 @@ $(document).ready(function() {
     let page_to_show = page_types[0];
 
     // see if a frame type was written in the query string, otherwise use default
-    let query_string = location.search;
-    if (query_string.length > 0) {
-        let query = query_string.substring(1, query_string.length);
-        // if (page_types.includes(query)) {
-        //     page_to_show = query;
-        // }
+    // query format: ?frame=TEST_METHODS
+    let query_string = new URLSearchParams(location.search);
+
+    if (query_string.has('frame')) {
+        let query = query_string.get('frame');
 
         // checks if substring of query matches an element in page_types
         // this allows flexibility and additional string in query (esp for bm_color)
@@ -102,6 +101,7 @@ function bodymap_main() {
 
     let frame = new BodyMapFrame(frame_data);
     frame.render();
+    console.log(frame.get_user_input());
 }
 
 function intro_main() {
@@ -116,6 +116,20 @@ function bodymap_color_main() {
     let sample_app = SAMPLE_APP;
     let frame_data = sample_app.body[2];
 
+    // need to add constants to constants.js!
+    let emotions = ['anger', 'disgust', 'envy', 'fear', 'guilt', 'happiness', 'love', 'sadness', 'shame'];
+    let bodyparts = ['head', 'neck', 'arms', 'chest', 'belly', 'legs'];
+    frame_data.emotion = null;      // by default
+    frame_data.bodypart = null;     // by default
+
+    // query format: ?frame=bodymap_color&emotion=EMOTION&bodypart=BODYPART
+    var query = new URLSearchParams(location.search);
+    if (query.has('emotion') && query.has('bodypart')) {
+        if (emotions.includes(query.get('emotion')) && bodyparts.includes(query.get('bodypart'))) {
+            frame_data.emotion = query.get('emotion');
+            frame_data.bodypart = query.get('bodypart');
+        }
+    }
     let frame = new BodyMapColorFrame(frame_data);
     frame.render();
 }

--- a/appside/test_frames.js
+++ b/appside/test_frames.js
@@ -13,10 +13,10 @@ $(document).ready(function() {
         'summary_count': summary_count_frame_main,
         'summary_qual': summary_qualifier_frame_main,
         'selection': selection_frame_main,
-        'bodymap': bodymap_main,
         'intro': intro_main,
-        'bodymap_color': bodymap_color_main,
         'bodymap_color_fwd': bodymap_color_fwd_main,
+        'bodymap_color': bodymap_color_main,
+        'bodymap': bodymap_main,
     };
 
     let page_types = Object.keys(test_methods);
@@ -26,7 +26,19 @@ $(document).ready(function() {
     let query_string = location.search;
     if (query_string.length > 0) {
         let query = query_string.substring(1, query_string.length);
-        if (page_types.includes(query)) {
+        // if (page_types.includes(query)) {
+        //     page_to_show = query;
+        // }
+
+        // checks if substring of query matches an element in page_types
+        // this allows flexibility and additional string in query (esp for bm_color)
+        var contains = function(element) {
+            if (query.includes(element)) {
+                query = element;
+                return true;
+            } // stops searching each element if true or no more elements to search
+        };
+        if (page_types.some(contains)) {
             page_to_show = query;
         }
     }


### PR DESCRIPTION
 ** **Pushed commits for both bodymap (statements) and bodymap_color in same branch!
All changes for userInput() for bodymap statements comes _after_ commit msg 'userInput() for bm_color'.**

**bodymap statements**: (after commit _userInput() for bm_color_)
`body.js`:
- user_input field: map with _keys_ as the statements' id (label1 etc.) and _values_ as boolean 📥 
- `render()` created 'NEXT' button as event listener that updates user_input field
- `userInput()` returned user_input field ⬅️

**bodymap color**: (before commit _userInput() for bodymap_)
`body.js`:
- user_input field: map with _keys_: 'emotion', 'bodypart', and 'answer'. Value of answer is qualifier itself 📥 
- changed to display individual frames as a specific emotion and body part. (removed links to other emotions/body part)
- added query check to display correct emotion/body part
- `render()` created 'NEXT' button as event listener that updates user_input field
- `userInput()` returned user_input field ⬅️

`test_frames.js`:
- changed query to allow more flexibility in query of URL 💪
(ex: '?bodymap_color/anger_head' will still render frame 'bodymap_color')