### PR TITLE
DBT graphic

### DIFF
--- a/appside/data/constants.js
+++ b/appside/data/constants.js
@@ -29,6 +29,7 @@ var BODY_STATEMENTS_PER_PAGE = 12;
 var BODY_FRAME_TEMPLATE = 'statements';
 var EMOTION_TYPE = ['anger', 'disgust', 'envy', 'fear', 'guilt', 'happiness', 'love', 'sadness', 'shame'];
 var BODY_PART = ['head', 'neck', 'arms', 'chest', 'belly', 'legs'];
+var SVG_URL = 'http://www.w3.org/2000/svg';
 
 // Intro frame strings
 var INTRO_TITLE = {};

--- a/appside/data/constants.js
+++ b/appside/data/constants.js
@@ -27,6 +27,8 @@ var SUMMARY_TEMPLATE_QUAL = 'qual';
 // Body config (all DBT worksheet models)
 var BODY_STATEMENTS_PER_PAGE = 12;
 var BODY_FRAME_TEMPLATE = 'statements';
+var EMOTION_TYPE = ['anger', 'disgust', 'envy', 'fear', 'guilt', 'happiness', 'love', 'sadness', 'shame'];
+var BODY_PART = ['head', 'neck', 'arms', 'chest', 'belly', 'legs'];
 
 // Intro frame strings
 var INTRO_TITLE = {};

--- a/appside/data/sample_app.js
+++ b/appside/data/sample_app.js
@@ -45,7 +45,7 @@ var SAMPLE_APP = {
             'title': 'Body map example slide',
             'question': 'What is your favorite body part?',
             'graphic': null,
-            'emotion': null,    // if null, graphic is black silhouette
+            'bodypart': null,    // if null, graphic is black silhouette
             'statements': [
                 ['Head', false, 'head'],
                 ['Shoulders', false, 'chest'],

--- a/appside/data/sample_app.js
+++ b/appside/data/sample_app.js
@@ -33,6 +33,7 @@ var SAMPLE_APP = {
             'template': 'statements',
             'title': 'Kittens',
             'question': 'What makes a kitten adorable?',
+            'graphic': null,
             'statements': [
                 ['its purr', false, 'correct'],
                 ['its floof', true, 'correct'],
@@ -43,11 +44,12 @@ var SAMPLE_APP = {
             'template': 'bodymap_statements',
             'title': 'Body map example slide',
             'question': 'What is your favorite body part?',
+            'graphic': null,
             'statements': [
-                'Head',
-                'Shoulders',
-                'Knees',
-                'Toes',
+                ['Head', false, 'head'],
+                ['Shoulders', false, 'chest'],
+                ['Knees', false, 'legs'],
+                ['Toes', false, 'legs'],
             ],
         },
         2: {
@@ -71,6 +73,7 @@ var SAMPLE_APP = {
             'template': 'words',
             'title': 'Word selection example',
             'question': 'Which words are palindromes?',
+            'graphic': null,
             'words': [
                 ['pop', false, 'palindrome'],
                 ['radar', true, 'palindrome'],

--- a/appside/data/sample_app.js
+++ b/appside/data/sample_app.js
@@ -45,6 +45,7 @@ var SAMPLE_APP = {
             'title': 'Body map example slide',
             'question': 'What is your favorite body part?',
             'graphic': null,
+            'emotion': null,
             'statements': [
                 ['Head', false, 'head'],
                 ['Shoulders', false, 'chest'],

--- a/appside/data/sample_app.js
+++ b/appside/data/sample_app.js
@@ -45,7 +45,7 @@ var SAMPLE_APP = {
             'title': 'Body map example slide',
             'question': 'What is your favorite body part?',
             'graphic': null,
-            'emotion': null,
+            'emotion': null,    // if null, graphic is black silhouette
             'statements': [
                 ['Head', false, 'head'],
                 ['Shoulders', false, 'chest'],

--- a/appside/frames/body.js
+++ b/appside/frames/body.js
@@ -57,11 +57,23 @@ class ListBodyFrame extends Frame {
         $(title).attr('class', 'text-info text-uppercase mb-2');
         frame.appendChild(title);
 
-        let left = document.createElement('div');
-        $(left).attr('class', 'bodymap_frame_left');
+        let container = document.createElement('div');  // flexbox for content
+        $(container).attr('class', 'list_body_frame');
 
-        let right = document.createElement('div');
-        $(right).attr('class', 'bodymap_frame_right');
+        let right = document.createElement('div');  // if no graphic, it occupies entire container
+        $(right).attr('class', 'frame_right');
+
+        if (this.graphic != null) {
+            let left = document.createElement('div');
+            $(left).attr('class', 'frame_left');
+
+            let graphic = document.createElement('img');
+            $(graphic).attr('src', 'images/neutral.png');
+            $(graphic).attr('class', 'list_body_graphic');
+            left.appendChild(graphic);
+
+            container.appendChild(left);
+        }
 
         // insert a p node for the question
         let question = document.createElement('h2');
@@ -119,15 +131,8 @@ class ListBodyFrame extends Frame {
         }
         right.appendChild(statements);
 
-        if (this.graphic != null) {
-            var graphic = document.createElement('img');
-            $(graphic).attr('src', 'images/neutral.png');
-            $(graphic).attr('class', 'bodymap_img');
-            left.appendChild(graphic);
-        }
-
-        frame.appendChild(left);
-        frame.appendChild(right);
+        container.appendChild(right);
+        frame.appendChild(container);
         let old_frame = $('#frame')[0];
         old_frame.replaceWith(frame);
     }
@@ -216,100 +221,7 @@ class BodyMapFrame extends ListBodyFrame {
         super(frame_data);
 
         this.items = frame_data.statements;
-        // this.title = frame_data.title;
-        // this.question = frame_data.question;
-        // this.statements = frame_data.statements;
-        // this.user_input = new Map();
     }
-
-    /**
-     * Render a frame for the body maps template.
-     *
-     * @require -- DOM must have a div whose ID is 'frame'
-     *
-     * @effects -- Does not preserve former content of <div id="frame">.
-     *      Renders the data from the argument into that div,
-     *      including graphic for body map.
-     *
-     **/
-     
-    // render() {
-    //     // make a new empty div with id frame, not yet in the dom
-    //     let frame = document.createElement('div');
-    //     $(frame).attr('id', 'frame');
-    //     let title = document.createElement('h2');
-    //     $(title).text(this.title);
-    //     frame.appendChild(title);
-
-    //     let left = document.createElement('div');
-    //     $(left).attr('class', 'bodymap_frame_left');
-
-    //     let right = document.createElement('div');
-    //     $(right).attr('class', 'bodymap_frame_right');
-
-    //     // body maps graphic column
-    //     var graphic = document.createElement('img');
-    //     $(graphic).attr('src', 'images/neutral.png');
-    //     $(graphic).attr('class', 'bodymap_img');
-    //     left.appendChild(graphic);
-
-    //     let question = document.createElement('h4');
-    //     $(question).text(this.question);
-    //     right.appendChild(question);
-
-    //     // checkboxes
-    //     let i = 0;
-    //     for (let stmt of this.statements) {
-    //         let name = 'label' + i;
-    //         i++;
-
-    //         let check = document.createElement('input');
-    //         $(check).attr('type', 'checkbox');
-    //         $(check).attr('id', name);
-    //         check.dataset.text = stmt;
-    //         right.appendChild(check);
-
-    //         let label = document.createElement('label');
-    //         $(label).attr('for', name);
-    //         $(label).text(stmt);
-
-    //         right.appendChild(label);
-    //         right.appendChild(document.createElement('br'));
-
-    //         this.user_input.set(stmt, 'false'); // all unchecked
-    //     }
-
-    //     // next will be implemented in navigator?
-    //     let next = document.createElement('button');
-    //     $(next).attr('class', 'bodymap_button');
-    //     $(next).text('Next');
-    //     right.appendChild(next);
-
-    //     // append both columns to frame
-    //     frame.appendChild(right);
-    //     frame.appendChild(left);
-
-    //     let old_frame = $('#frame')[0];
-    //     old_frame.replaceWith(frame);
-    // }
-
-    /**
-     * Returns map of user input
-     * if render() is called, map with keys as each statement's text and value boolean;
-     * otherwise, returns uninitialized map
-     * @return map of user input
-     */
-    // get_user_input() {
-    //     var choices = document.getElementsByTagName('input');
-    //     for (let each of choices) {
-    //         if (each.checked) {
-    //             this.user_input.set(each.dataset.text, 'true');
-    //         } else {
-    //             this.user_input.set(each.dataset.text, 'false');
-    //         }
-    //     }
-    //     return this.user_input;
-    // }
 }
 
 /**

--- a/appside/frames/body.js
+++ b/appside/frames/body.js
@@ -35,6 +35,7 @@ class ListBodyFrame extends Frame {
         this.question = frame_data.question;
         this.user_input = new Map();
         this.graphic = frame_data.graphic;
+        this.emotion = null;    // only currently used in BodyMapFrame
     }
 
     /**

--- a/appside/frames/body.js
+++ b/appside/frames/body.js
@@ -68,7 +68,11 @@ class ListBodyFrame extends Frame {
             $(left).attr('class', 'frame_left');
 
             let graphic = document.createElement('img');
-            $(graphic).attr('src', 'images/neutral.png');
+            if (this.emotion != null) {
+                $(graphic).attr('src', 'images/' + this.emotion + '.png');
+            } else {
+                $(graphic).attr('src', 'images/neutral.png');
+            }
             $(graphic).attr('class', 'list_body_graphic');
             left.appendChild(graphic);
 
@@ -214,12 +218,14 @@ class BodyMapFrame extends ListBodyFrame {
      * @param frame_data -- Object containing the frame's data. Expected fields:
      *      frame_data.title (string)
      *      frame_data.question (string) -- text before checkboxes
+     *      frame_data.emotion (string) -- emotion type
      *      frame_data.statements (list of string) -- checkbox statements
      * Behavior undefined if frame doe snot have these properties.
      **/
     constructor(frame_data) {
         super(frame_data);
 
+        this.emotion = frame_data.emotion;
         this.items = frame_data.statements;
     }
 }

--- a/appside/frames/body.js
+++ b/appside/frames/body.js
@@ -34,6 +34,7 @@ class ListBodyFrame extends Frame {
         this.title = frame_data.title;
         this.question = frame_data.question;
         this.user_input = new Map();
+        this.graphic = frame_data.graphic;
     }
 
     /**
@@ -56,11 +57,17 @@ class ListBodyFrame extends Frame {
         $(title).attr('class', 'text-info text-uppercase mb-2');
         frame.appendChild(title);
 
+        let left = document.createElement('div');
+        $(left).attr('class', 'bodymap_frame_left');
+
+        let right = document.createElement('div');
+        $(right).attr('class', 'bodymap_frame_right');
+
         // insert a p node for the question
         let question = document.createElement('h2');
         $(question).text(this.question);
         $(question).attr('class', 'font-weight-light mb-4');
-        frame.appendChild(question);
+        right.appendChild(question);
         
         // insert a checkbox list for the statements
         let statements = document.createElement('div');
@@ -110,8 +117,17 @@ class ListBodyFrame extends Frame {
             
             statements.appendChild(document.createElement('br'));
         }
-        frame.appendChild(statements);
+        right.appendChild(statements);
 
+        if (this.graphic != null) {
+            var graphic = document.createElement('img');
+            $(graphic).attr('src', 'images/neutral.png');
+            $(graphic).attr('class', 'bodymap_img');
+            left.appendChild(graphic);
+        }
+
+        frame.appendChild(left);
+        frame.appendChild(right);
         let old_frame = $('#frame')[0];
         old_frame.replaceWith(frame);
     }
@@ -185,7 +201,7 @@ class WordsBodyFrame extends ListBodyFrame {
  * Frame consists of a list of statements relating to body sensations
  * and a body map image.
  */
-class BodyMapFrame extends Frame {
+class BodyMapFrame extends ListBodyFrame {
 
      /**
      * Construct a body map frame
@@ -197,12 +213,13 @@ class BodyMapFrame extends Frame {
      * Behavior undefined if frame doe snot have these properties.
      **/
     constructor(frame_data) {
-        super();
+        super(frame_data);
 
-        this.title = frame_data.title;
-        this.question = frame_data.question;
-        this.statements = frame_data.statements;
-        this.user_input = new Map();
+        this.items = frame_data.statements;
+        // this.title = frame_data.title;
+        // this.question = frame_data.question;
+        // this.statements = frame_data.statements;
+        // this.user_input = new Map();
     }
 
     /**
@@ -216,65 +233,65 @@ class BodyMapFrame extends Frame {
      *
      **/
      
-    render() {
-        // make a new empty div with id frame, not yet in the dom
-        let frame = document.createElement('div');
-        $(frame).attr('id', 'frame');
-        let title = document.createElement('h2');
-        $(title).text(this.title);
-        frame.appendChild(title);
+    // render() {
+    //     // make a new empty div with id frame, not yet in the dom
+    //     let frame = document.createElement('div');
+    //     $(frame).attr('id', 'frame');
+    //     let title = document.createElement('h2');
+    //     $(title).text(this.title);
+    //     frame.appendChild(title);
 
-        let left = document.createElement('div');
-        $(left).attr('class', 'bodymap_frame_left');
+    //     let left = document.createElement('div');
+    //     $(left).attr('class', 'bodymap_frame_left');
 
-        let right = document.createElement('div');
-        $(right).attr('class', 'bodymap_frame_right');
+    //     let right = document.createElement('div');
+    //     $(right).attr('class', 'bodymap_frame_right');
 
-        // body maps graphic column
-        var graphic = document.createElement('img');
-        $(graphic).attr('src', 'images/neutral.png');
-        $(graphic).attr('class', 'bodymap_img');
-        left.appendChild(graphic);
+    //     // body maps graphic column
+    //     var graphic = document.createElement('img');
+    //     $(graphic).attr('src', 'images/neutral.png');
+    //     $(graphic).attr('class', 'bodymap_img');
+    //     left.appendChild(graphic);
 
-        let question = document.createElement('h4');
-        $(question).text(this.question);
-        right.appendChild(question);
+    //     let question = document.createElement('h4');
+    //     $(question).text(this.question);
+    //     right.appendChild(question);
 
-        // checkboxes
-        let i = 0;
-        for (let stmt of this.statements) {
-            let name = 'label' + i;
-            i++;
+    //     // checkboxes
+    //     let i = 0;
+    //     for (let stmt of this.statements) {
+    //         let name = 'label' + i;
+    //         i++;
 
-            let check = document.createElement('input');
-            $(check).attr('type', 'checkbox');
-            $(check).attr('id', name);
-            check.dataset.text = stmt;
-            right.appendChild(check);
+    //         let check = document.createElement('input');
+    //         $(check).attr('type', 'checkbox');
+    //         $(check).attr('id', name);
+    //         check.dataset.text = stmt;
+    //         right.appendChild(check);
 
-            let label = document.createElement('label');
-            $(label).attr('for', name);
-            $(label).text(stmt);
+    //         let label = document.createElement('label');
+    //         $(label).attr('for', name);
+    //         $(label).text(stmt);
 
-            right.appendChild(label);
-            right.appendChild(document.createElement('br'));
+    //         right.appendChild(label);
+    //         right.appendChild(document.createElement('br'));
 
-            this.user_input.set(stmt, 'false'); // all unchecked
-        }
+    //         this.user_input.set(stmt, 'false'); // all unchecked
+    //     }
 
-        // next will be implemented in navigator?
-        let next = document.createElement('button');
-        $(next).attr('class', 'bodymap_button');
-        $(next).text('Next');
-        right.appendChild(next);
+    //     // next will be implemented in navigator?
+    //     let next = document.createElement('button');
+    //     $(next).attr('class', 'bodymap_button');
+    //     $(next).text('Next');
+    //     right.appendChild(next);
 
-        // append both columns to frame
-        frame.appendChild(right);
-        frame.appendChild(left);
+    //     // append both columns to frame
+    //     frame.appendChild(right);
+    //     frame.appendChild(left);
 
-        let old_frame = $('#frame')[0];
-        old_frame.replaceWith(frame);
-    }
+    //     let old_frame = $('#frame')[0];
+    //     old_frame.replaceWith(frame);
+    // }
 
     /**
      * Returns map of user input
@@ -282,17 +299,17 @@ class BodyMapFrame extends Frame {
      * otherwise, returns uninitialized map
      * @return map of user input
      */
-    get_user_input() {
-        var choices = document.getElementsByTagName('input');
-        for (let each of choices) {
-            if (each.checked) {
-                this.user_input.set(each.dataset.text, 'true');
-            } else {
-                this.user_input.set(each.dataset.text, 'false');
-            }
-        }
-        return this.user_input;
-    }
+    // get_user_input() {
+    //     var choices = document.getElementsByTagName('input');
+    //     for (let each of choices) {
+    //         if (each.checked) {
+    //             this.user_input.set(each.dataset.text, 'true');
+    //         } else {
+    //             this.user_input.set(each.dataset.text, 'false');
+    //         }
+    //     }
+    //     return this.user_input;
+    // }
 }
 
 /**

--- a/appside/frames/body.js
+++ b/appside/frames/body.js
@@ -20,6 +20,7 @@ class ListBodyFrame extends Frame {
      *    frame_data.template -- The exact string 'statements'
      *    frame_data.title (string) -- The frame's title
      *    frame_data.question (string) -- Text to appear before the list of statements
+     *    frame_data.graphic (string) -- URL/path to image or null
      *  Behavior undefined if frame does not have these properties.
      */
     constructor(frame_data) {
@@ -35,7 +36,6 @@ class ListBodyFrame extends Frame {
         this.question = frame_data.question;
         this.user_input = new Map();
         this.graphic = frame_data.graphic;
-        this.bodypart = null;    // only currently used in BodyMapFrame
     }
 
     /**
@@ -61,43 +61,42 @@ class ListBodyFrame extends Frame {
         let container = document.createElement('div');  // flexbox for content
         $(container).attr('class', 'list_body_frame');
 
-        let right = document.createElement('div');  // if no graphic, it occupies entire container
-        $(right).attr('class', 'frame_right');
+        let text_column = document.createElement('div');  // if no graphic, it occupies entire container
+        $(text_column).attr('class', 'frame_text_column');
 
         if (this.graphic != null) {
-            let left = document.createElement('div');
-            $(left).attr('class', 'frame_left');
+            let graphic_column = document.createElement('div');
+            $(graphic_column).attr('class', 'frame_graphic_column');
             // SVG
-            let url = 'http://www.w3.org/2000/svg';
-            let bg = document.createElementNS(url, 'svg');
+            let bg = document.createElementNS(SVG_URL, 'svg');
             $(bg).attr('class', 'list_body_bg');
 
-            let img = document.createElementNS(url, 'image');
+            let img = document.createElementNS(SVG_URL, 'image');
             $(img).attr('class', 'list_body_graphic');
             $(img).attr('href', 'images/neutral.png');
             bg.appendChild(img);
 
             if (this.bodypart != null) {
-                let highlight = document.createElementNS(url, 'rect');
-                if (this.bodypart != "arms") {
+                let highlight = document.createElementNS(SVG_URL, 'rect');
+                if (this.bodypart != 'arms') {
                     $(highlight).attr('class', `list_body_graphic list_body_${this.bodypart}`);
                 } else {    // 2 SVG elements for arms
                     $(highlight).attr('class', `list_body_graphic list_body_arm1`);
-                    let highlight2 = document.createElementNS(url, 'rect');
+                    let highlight2 = document.createElementNS(SVG_URL, 'rect');
                     $(highlight2).attr('class', `list_body_graphic list_body_arm2`);
                     bg.appendChild(highlight2);
                 }
                 bg.appendChild(highlight);
             }
-            left.appendChild(bg);
-            container.appendChild(left);
+            graphic_column.appendChild(bg);
+            container.appendChild(graphic_column);
         }
 
         // insert a p node for the question
         let question = document.createElement('h2');
         $(question).text(this.question);
         $(question).attr('class', 'font-weight-light mb-4');
-        right.appendChild(question);
+        text_column.appendChild(question);
         
         // insert a checkbox list for the statements
         let statements = document.createElement('div');
@@ -147,9 +146,9 @@ class ListBodyFrame extends Frame {
             
             statements.appendChild(document.createElement('br'));
         }
-        right.appendChild(statements);
+        text_column.appendChild(statements);
 
-        container.appendChild(right);
+        container.appendChild(text_column);
         frame.appendChild(container);
         let old_frame = $('#frame')[0];
         old_frame.replaceWith(frame);
@@ -238,8 +237,8 @@ class BodyMapFrame extends ListBodyFrame {
      **/
     constructor(frame_data) {
         super(frame_data);
-
-        this.bodypart = frame_data.bodypart;
+        this.bodypart = frame_data.bodypart;   
+        this.graphic = '';
         this.items = frame_data.statements;
     }
 }
@@ -286,23 +285,23 @@ class BodyMapColorFrame extends Frame {
         $(title).text(this.title);
         frame.appendChild(title);
         
-        frame.left = document.createElement('div');             // displays body image and scale
-        $(frame.left).attr('class', 'bodymap_color_frame_left');
+        frame.graphic_column = document.createElement('div');             // displays body image and scale
+        $(frame.graphic_column).attr('class', 'bodymap_color_frame_graphic_column');
 
-        frame.right = document.createElement('div');            // displays questionnaire and NEXT button
-        $(frame.right).attr('class', 'bodymap_color_frame_right');
+        frame.text_column = document.createElement('div');            // displays questionnaire and NEXT button
+        $(frame.text_column).attr('class', 'bodymap_color_frame_text_column');
 
         let greeting = document.createElement('h4');            // displays when emotion/bodypart NOT specified
         $(greeting).text('Please select an emotion.');
-        frame.left.appendChild(greeting);
+        frame.graphic_column.appendChild(greeting);
 
         if (this.emotion != null && this.bodypart != null) {
-            this.render_left_col(frame);                    // only renders when emotion is specified
-            this.render_right_col(frame);                   // only renders when bodypart is specified
+            this.render_graphic_column(frame);                    // only renders when emotion is specified
+            this.render_text_column(frame);                   // only renders when bodypart is specified
         }
 
-        frame.appendChild(frame.left);
-        frame.appendChild(frame.right);
+        frame.appendChild(frame.graphic_column);
+        frame.appendChild(frame.text_column);
 
         let old_frame = $('#frame')[0];
         old_frame.replaceWith(frame);
@@ -310,21 +309,21 @@ class BodyMapColorFrame extends Frame {
 
     /** 
      * Private helper method for bodymap_color
-     * Renders frame.left
+     * Renders frame.graphic_column
      *
      * @param frame -- div that holds content of template
-     *          frame.left (div) -- holds content from this function
+     *          frame.graphic_column (div) -- holds content from this function
      * 
      * @requires
      *          this.emotion (String) exists
      *          this.bodyparts (array of String) contains the 6 body parts
      *
-     * @effects -- does not preserve any content from frame.left
+     * @effects -- does not preserve any content from frame.graphic_column
      *      Renders specified emotion graphic, cropped to specified bodypart,
      *      and displays scale.png
      **/
-    render_left_col(frame) {
-        frame.left.innerHTML = '';
+    render_graphic_column(frame) {
+        frame.graphic_column.innerHTML = '';
         const bodymap = document.createElement('img');
         $(bodymap).attr('class', 'bodymap_color_img');
         if (this.emotion != null) {
@@ -334,41 +333,41 @@ class BodyMapColorFrame extends Frame {
         if (this.bodypart != null) {      // clipping picture when specified body part
             $(bodymap).attr('class', `bodymap_color_img bodymap_color_${this.bodypart}`);
         }
-        frame.left.appendChild(bodymap);    
+        frame.graphic_column.appendChild(bodymap);    
 
         const bg_image = document.createElement('img');
         $(bg_image).attr('src', 'images/outline.png');
         $(bg_image).attr('class', 'bodymap_color_bg_img');
-        frame.left.appendChild(bg_image);
+        frame.graphic_column.appendChild(bg_image);
 
         const scale = document.createElement('img');
         $(scale).attr('src', 'images/scale.png');
         $(scale).attr('class', 'bodymap_color_scale_img');
-        frame.left.appendChild(scale);
+        frame.graphic_column.appendChild(scale);
     }
 
     /**
      * Private helper method for bodymap_color
-     * Renders frame.right
+     * Renders frame.text_column
      *
-     * @param frame -- div frame must contain frame.right
-     *          frame.right (div) -- holds content from this function
+     * @param frame -- div frame must contain frame.text_column
+     *          frame.text_column (div) -- holds content from this function
      * 
      * @requires
      *          this.bodypart (String) be an element in bodyparts
      *          this.question (String) exists
      *          this.qualifiers (array of String) contains answer choices
      *
-     * @effects -- does not preserve any content from frame.right
+     * @effects -- does not preserve any content from frame.text_column
      *      If no specified bodypart, renders links to each bodypart
      *      If specified body part, renders questionnaire
      **/
-    render_right_col(frame) {
-        frame.right.innerHTML = '';
+    render_text_column(frame) {
+        frame.text_column.innerHTML = '';
         let question = document.createElement('p');
         var string = this.bodypart + ' in ' + this.emotion;
         $(question).text(this.question.replace('{}', string));
-        frame.right.appendChild(question);
+        frame.text_column.appendChild(question);
 
         for (let choice of this.qualifiers) {
             let radio = document.createElement('input');
@@ -380,16 +379,16 @@ class BodyMapColorFrame extends Frame {
             let label = document.createElement('label');
             $(label).attr('for', choice);
             $(label).text(choice);
-            frame.right.appendChild(radio);
-            frame.right.appendChild(label);
-            frame.right.appendChild(document.createElement('br'));
+            frame.text_column.appendChild(radio);
+            frame.text_column.appendChild(label);
+            frame.text_column.appendChild(document.createElement('br'));
         }
 
         // next will be implemented in navigator?
         let next = document.createElement('button');
         $(next).attr('class', 'bodymap_color_button');
         $(next).text('Next');
-        frame.right.appendChild(next);
+        frame.text_column.appendChild(next);
 
     }
 
@@ -471,7 +470,7 @@ class BodyMapColorFwdFrame extends Frame {
 
         let inc = new BodyMapCanvas(frame.left, this.colors[0], this.texts[0]);
         $(inc).attr('class', 'bodymap_color_fwd_canvas_inc');
-        let dec = new BodyMapCanvas(frame.right, this.colors[1], this.texts[1]);
+        let dec = new BodyMapCanvas(frame.text_column, this.colors[1], this.texts[1]);
         $(dec).attr('class', 'bodymap_color_fwd_canvas_dec');
         inc.render();
         dec.render();
@@ -519,48 +518,45 @@ class BodyMapCanvas {
         this.frame.appendChild(text);
 
         // SVG
-        let url = 'http://www.w3.org/2000/svg';
-        let bg = document.createElementNS(url, 'svg');
+        let bg = document.createElementNS(SVG_URL, 'svg');
         $(bg).attr('class', 'bodymap_canvas_bg');
 
-        let img = document.createElementNS(url, 'image');
+        let img = document.createElementNS(SVG_URL, 'image');
         $(img).attr('class', 'bodymap_canvas_img');
         $(img).attr('href', 'images/outline.png');
         bg.appendChild(img);
 
         // Body Part Click Sections
-        // "polygon points can only be specified as element attribute, not CSS"
-        // - tinyurl.com/svgPolygon
-        let head = document.createElementNS(url, 'rect');
+        let head = document.createElementNS(SVG_URL, 'rect');
         $(head).attr('class', 'bodymap_canvas_head');
 
-        let neck = document.createElementNS(url, 'rect');
+        let neck = document.createElementNS(SVG_URL, 'rect');
         $(neck).attr('class', 'bodymap_canvas_neck');
 
-        let arm_left = document.createElementNS(url, 'polygon'); // left from client view
+        let arm_left = document.createElementNS(SVG_URL, 'polygon'); // left from client view
         $(arm_left).attr('class', 'bodymap_canvas_arm_left');
         $(arm_left).attr('points', '28,110 50,105 35,200 27,220 27,260 23,290 23,300 7,300 5,280 3,270 3,230 15,170 15,140');
 
-        let arm_right = document.createElementNS(url, 'polygon')    // right from client view
+        let arm_right = document.createElementNS(SVG_URL, 'polygon')    // right from client view
         $(arm_right).attr('class', 'bodymap_canvas_arm_right');
         $(arm_right).attr('points', '120,100 150,115 160,150 160,170 172,230 172,250 170,300 150,300 150,295 146,260 145,218 140,200');
 
-        let hands = document.createElementNS(url, 'polygon');
+        let hands = document.createElementNS(SVG_URL, 'polygon');
         $(hands).attr('class', 'bodymap_canvas_hands');
         $(hands).attr('points', '23,300 28,320 28,331 32,340 30,344 15,344 5,330 7,300 170,300 170,310 172,330 163,345 147,345 142,340 145,335 145,320 150,300');
 
-        let chest = document.createElementNS(url, 'polygon');
+        let chest = document.createElementNS(SVG_URL, 'polygon');
         $(chest).attr('class', 'bodymap_canvas_chest');
         $(chest).attr('points', '50,105 70,93 105,93 120,100 138,195 132,220 135,270 40,270 43,220 37,195');
 
-        let belly = document.createElementNS(url, 'rect');
+        let belly = document.createElementNS(SVG_URL, 'rect');
         $(belly).attr('class', 'bodymap_canvas_belly');
 
-        let legs = document.createElementNS(url, 'polygon');
+        let legs = document.createElementNS(SVG_URL, 'polygon');
         $(legs).attr('class', 'bodymap_canvas_legs');
         $(legs).attr('points', '40,250 137,255 140,340 130,385 125,440 125,490 110,555 87,555 93,525 88,480 90,450 90,400 87,370 83,410 83,450 84,490 82,520 87,555 63,555 50,490 48,400 36,335 37,260');
 
-        let feet = document.createElementNS(url, 'polygon');
+        let feet = document.createElementNS(SVG_URL, 'polygon');
         $(feet).attr('class', 'bodymap_canvas_feet');
         $(feet).attr('points', '87,555 110,555 120,590 110,595 95,595 87,585 87,555 87,585 80,595 60,595 55,585 63,570 63,555');
 

--- a/appside/frames/body.js
+++ b/appside/frames/body.js
@@ -35,7 +35,7 @@ class ListBodyFrame extends Frame {
         this.question = frame_data.question;
         this.user_input = new Map();
         this.graphic = frame_data.graphic;
-        this.emotion = null;    // only currently used in BodyMapFrame
+        this.bodypart = null;    // only currently used in BodyMapFrame
     }
 
     /**
@@ -67,16 +67,29 @@ class ListBodyFrame extends Frame {
         if (this.graphic != null) {
             let left = document.createElement('div');
             $(left).attr('class', 'frame_left');
+            // SVG
+            let url = 'http://www.w3.org/2000/svg';
+            let bg = document.createElementNS(url, 'svg');
+            $(bg).attr('class', 'list_body_bg');
 
-            let graphic = document.createElement('img');
-            if (this.emotion != null) {
-                $(graphic).attr('src', 'images/' + this.emotion + '.png');
-            } else {
-                $(graphic).attr('src', 'images/neutral.png');
+            let img = document.createElementNS(url, 'image');
+            $(img).attr('class', 'list_body_graphic');
+            $(img).attr('href', 'images/neutral.png');
+            bg.appendChild(img);
+
+            if (this.bodypart != null) {
+                let highlight = document.createElementNS(url, 'rect');
+                if (this.bodypart != "arms") {
+                    $(highlight).attr('class', `list_body_graphic list_body_${this.bodypart}`);
+                } else {    // 2 SVG elements for arms
+                    $(highlight).attr('class', `list_body_graphic list_body_arm1`);
+                    let highlight2 = document.createElementNS(url, 'rect');
+                    $(highlight2).attr('class', `list_body_graphic list_body_arm2`);
+                    bg.appendChild(highlight2);
+                }
+                bg.appendChild(highlight);
             }
-            $(graphic).attr('class', 'list_body_graphic');
-            left.appendChild(graphic);
-
+            left.appendChild(bg);
             container.appendChild(left);
         }
 
@@ -219,14 +232,14 @@ class BodyMapFrame extends ListBodyFrame {
      * @param frame_data -- Object containing the frame's data. Expected fields:
      *      frame_data.title (string)
      *      frame_data.question (string) -- text before checkboxes
-     *      frame_data.emotion (string) -- emotion type
+     *      frame_data.bodypart (string) -- type of body part
      *      frame_data.statements (list of string) -- checkbox statements
      * Behavior undefined if frame doe snot have these properties.
      **/
     constructor(frame_data) {
         super(frame_data);
 
-        this.emotion = frame_data.emotion;
+        this.bodypart = frame_data.bodypart;
         this.items = frame_data.statements;
     }
 }

--- a/appside/styles/frames.css
+++ b/appside/styles/frames.css
@@ -77,6 +77,22 @@ body {
     background: #FFF;
 }
 
+.list_body_frame {
+  justify-content: center;
+  align-items: flex-start;
+  display: flex;
+  flex-direction: row;
+}
+.list_body_frame > .frame_left, .frame_right {
+  height: 100%;
+  margin: 10px;
+
+}
+.list_body_graphic {
+  max-width: 100%;
+  height: auto;
+}
+
 .bodymap_frame_left, .bodymap_frame_right, .bodymap_color_frame_left, .bodymap_color_frame_right {
   width: 300px;
   height: 100%;

--- a/appside/styles/frames.css
+++ b/appside/styles/frames.css
@@ -79,19 +79,87 @@ body {
 }
 
 .list_body_frame {
-  justify-content: center;
-  align-items: flex-start;
-  display: flex;
-  flex-direction: row;
+    justify-content: center;
+    align-items: flex-start;
+    display: flex;
+    flex-direction: row;
 }
 .list_body_frame > .frame_left, .frame_right {
-  height: 100%;
-  margin: 10px;
-
+    height: 100%;
+    width: 100%;
+    margin: 10px;
 }
+.list_body_bg {
+    height: 500px;
+    width: auto;
+}
+
 .list_body_graphic {
-  max-width: 90%;
-  height: auto;
+    width: 100%;
+    height: 100%;
+    stroke-width: 4;
+    stroke: gray;
+    fill: none;
+}
+
+.list_body_head {
+    width: 45px;
+    height: 65px;
+    x: 127px;
+    y: 5px;
+    rx: 40px;
+    ry: 40px;
+}
+
+.list_body_neck {
+    width: 25px;
+    height: 20px;
+    x: 137px;
+    y: 63px;
+    rx: 5px;
+    ry: 5px;
+}
+
+.list_body_chest {
+    width: 90px;
+    height: 110px;
+    x: 105px;
+    y: 80px;
+    rx: 55px;
+    ry: 70px;
+}
+
+.list_body_belly {
+    width: 80px;
+    height: 70px;
+    x: 110px;
+    y: 165px;
+    rx: 55px;
+    ry: 70px;
+}
+.list_body_legs {
+    width: 100px;
+    height: 240px;
+    x: 100px;
+    y: 260px;
+    rx: 50px;
+    ry: 100px;
+}
+.list_body_arm1 {
+    width: 60px;
+    height: 210px;
+    x: 60px;
+    y: 90px;
+    rx: 40px;
+    ry: 105px;
+}
+.list_body_arm2 {
+    width: 60px;
+    height: 210px;
+    x: 175px;
+    y: 90px;
+    rx: 40px;
+    ry: 105px;
 }
 
 .bodymap_frame_left, .bodymap_frame_right, .bodymap_color_frame_left, .bodymap_color_frame_right {

--- a/appside/styles/frames.css
+++ b/appside/styles/frames.css
@@ -73,6 +73,7 @@ body {
 
 .container-fixed {
     width: 800px;
+    margin: auto;
     height: auto;
     background: #FFF;
 }
@@ -89,7 +90,7 @@ body {
 
 }
 .list_body_graphic {
-  max-width: 100%;
+  max-width: 90%;
   height: auto;
 }
 

--- a/appside/styles/frames.css
+++ b/appside/styles/frames.css
@@ -84,7 +84,7 @@ body {
     display: flex;
     flex-direction: row;
 }
-.list_body_frame > .frame_left, .frame_right {
+.list_body_frame > .frame_left, .frame_text_column {
     height: 100%;
     width: 100%;
     margin: 10px;
@@ -162,7 +162,7 @@ body {
     ry: 105px;
 }
 
-.bodymap_frame_left, .bodymap_frame_right, .bodymap_color_frame_left, .bodymap_color_frame_right {
+.bodymap_frame_graphic_column, .bodymap_frame_text_column, .bodymap_color_frame_graphic_column, .bodymap_color_frame_text_column {
   width: 300px;
   height: 100%;
   position: absolute;
@@ -188,11 +188,11 @@ body {
   top: 40px;
 }
 
-.bodymap_frame_left, .bodymap_color_frame_left, .bodymap_color_fwd_frame_left {
+.bodymap_frame_graphic_column, .bodymap_color_frame_graphic_column, .bodymap_color_fwd_frame_left {
   left: 0px;
 }
 
-.bodymap_frame_right, .bodymap_color_frame_right, .bodymap_color_fwd_frame_center {
+.bodymap_frame_text_column, .bodymap_color_frame_text_column, .bodymap_color_fwd_frame_center {
   left: 300px;
 }
 

--- a/appside/test_frames.html
+++ b/appside/test_frames.html
@@ -31,6 +31,8 @@
   <!-- data files -->
   <script src="data/knowledgebase.js"></script>
   <script src="data/sample_app.js"></script>
+  <script src="data/constants.js"></script>
+
 
   <script src="test_frames.js"></script>
   <script src="frames/frame.js"></script>

--- a/appside/test_frames.js
+++ b/appside/test_frames.js
@@ -87,7 +87,6 @@ function selection_frame_main() {
 function bodymap_main() {
     let sample_app = SAMPLE_APP;
     let frame_data = sample_app.body[1];
-    frame_data.graphic = 'chest';
 
     var query = new URLSearchParams(location.search);
     if (query.has('bodypart')) {
@@ -97,7 +96,6 @@ function bodymap_main() {
     }
     let frame = new BodyMapFrame(frame_data);
     frame.render();
-    console.log(frame.get_user_input());
 }
 
 function intro_main() {
@@ -119,12 +117,6 @@ function intro_nographic_main() {
 function bodymap_color_main() {
     let sample_app = SAMPLE_APP;
     let frame_data = sample_app.body[2];
-
-    // Added these constants EMOTION_TYPE and BODY_PART under body config in constants.js
-    // let emotions = ['anger', 'disgust', 'envy', 'fear', 'guilt', 'happiness', 'love', 'sadness', 'shame'];
-    // let bodyparts = ['head', 'neck', 'arms', 'chest', 'belly', 'legs'];
-    // let emotions = EMOTION_TYPE;
-    // let bodyparts = BODY_PART;
     frame_data.emotion = null;      // by default
     frame_data.bodypart = null;     // by default
 

--- a/appside/test_frames.js
+++ b/appside/test_frames.js
@@ -87,6 +87,7 @@ function selection_frame_main() {
 function bodymap_main() {
     let sample_app = SAMPLE_APP;
     let frame_data = sample_app.body[1];
+    frame_data.graphic = 'head';
 
     let frame = new BodyMapFrame(frame_data);
     frame.render();

--- a/appside/test_frames.js
+++ b/appside/test_frames.js
@@ -87,8 +87,14 @@ function selection_frame_main() {
 function bodymap_main() {
     let sample_app = SAMPLE_APP;
     let frame_data = sample_app.body[1];
-    frame_data.graphic = 'head';
+    frame_data.graphic = 'chest';
 
+    var query = new URLSearchParams(location.search);
+    if (query.has('emotion')) {
+        if (EMOTION_TYPE.includes(query.get('emotion'))) {
+            frame_data.emotion = query.get('emotion');
+        }
+    }
     let frame = new BodyMapFrame(frame_data);
     frame.render();
     console.log(frame.get_user_input());
@@ -114,16 +120,18 @@ function bodymap_color_main() {
     let sample_app = SAMPLE_APP;
     let frame_data = sample_app.body[2];
 
-    // need to add constants to constants.js!
-    let emotions = ['anger', 'disgust', 'envy', 'fear', 'guilt', 'happiness', 'love', 'sadness', 'shame'];
-    let bodyparts = ['head', 'neck', 'arms', 'chest', 'belly', 'legs'];
+    // Added these constants EMOTION_TYPE and BODY_PART under body config in constants.js
+    // let emotions = ['anger', 'disgust', 'envy', 'fear', 'guilt', 'happiness', 'love', 'sadness', 'shame'];
+    // let bodyparts = ['head', 'neck', 'arms', 'chest', 'belly', 'legs'];
+    // let emotions = EMOTION_TYPE;
+    // let bodyparts = BODY_PART;
     frame_data.emotion = null;      // by default
     frame_data.bodypart = null;     // by default
 
     // query format: ?frame=bodymap_color&emotion=EMOTION&bodypart=BODYPART
     var query = new URLSearchParams(location.search);
     if (query.has('emotion') && query.has('bodypart')) {
-        if (emotions.includes(query.get('emotion')) && bodyparts.includes(query.get('bodypart'))) {
+        if (EMOTION_TYPE.includes(query.get('emotion')) && BODY_PART.includes(query.get('bodypart'))) {
             frame_data.emotion = query.get('emotion');
             frame_data.bodypart = query.get('bodypart');
         }

--- a/appside/test_frames.js
+++ b/appside/test_frames.js
@@ -90,9 +90,9 @@ function bodymap_main() {
     frame_data.graphic = 'chest';
 
     var query = new URLSearchParams(location.search);
-    if (query.has('emotion')) {
-        if (EMOTION_TYPE.includes(query.get('emotion'))) {
-            frame_data.emotion = query.get('emotion');
+    if (query.has('bodypart')) {
+        if (BODY_PART.includes(query.get('bodypart'))) {
+            frame_data.bodypart = query.get('bodypart');
         }
     }
     let frame = new BodyMapFrame(frame_data);


### PR DESCRIPTION
Issue #42 
### Minor changes:
`constants.js`: adds emotion, bodypart, svg url constants as **EMOTION, BODY_PART, SVG_URL**
`test_frames.html`: includes `constants.js` to this html file
`sample_app.js`:
* adds **graphic field** to child frames of ListBodyFrame (words, statements, and bodymap)
* adds **bodypart field** to bodymap template and set to null

`test_frames.js`: checks **query** for specified body part (if none, uses null)

### Major changes:
`body.js`:
* Sets BodyMapFrame as **child of ListBodyFrame** 👶 (_major code simplification_)
* Adds **graphic and bodypart field** to ListBodyFrame
* Adds **optional graphic feature** to ListBodyFrame (and specific graphic if specified body part)
* Changed all frames 'left' and 'right' to 'graphic_column' and 'text_column' respectively
_(except bodymap_color_fwd frame)_

`frames.css`:
* Flexible display of frames 💎
(if graphic, graphic is on left and answer choices on right; else, takes up entire space)
* Changed all frames 'left' and 'right' to 'graphic_column' and 'text_column'